### PR TITLE
Fix to address Windows build fail.

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -11,7 +11,6 @@ impl<'a, I: Iterator<Item = Event<'a>>> Consumer<'a, I> {
     /// Consume the pull parser to produce the HTML string output
     fn consume(&mut self) -> String {
         while let Some(event) = self.iter.next() {
-            debug!("{:?}", event);
             match event {
                 Event::Start(tag) => {
                     self.buffer.push_str(&print_start_elem(&tag));
@@ -70,7 +69,6 @@ fn print_start_elem(tag: &Tag) -> String {
         }
     };
 
-    debug!("{:?}", result);
     result
 }
 
@@ -99,7 +97,6 @@ fn print_end_elem(tag: &Tag) -> String {
         }
     };
 
-    debug!("{:?}", result);
     result
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub struct ConvertedFile {
 impl Convertor {
     /// Initialize a new convertor for the provided root directory
     pub fn new<P: AsRef<Path>>(root_dir: P) -> Result<Convertor, ConvError> {
-        let root_dir: PathBuf = fs::canonicalize(&root_dir).unwrap();
+        let root_dir: PathBuf = root_dir.as_ref().to_path_buf();
         info!("Generating site from directory: {}", root_dir.display());
         let configuration = read_config(&root_dir)?;
         handle_config(&root_dir, &configuration)?;

--- a/tests/all_test.rs
+++ b/tests/all_test.rs
@@ -1,28 +1,30 @@
 extern crate made_up;
-// extern crate tempdir;
+extern crate log;
 use std::fs;
 use std::env;
-use std::path::PathBuf;
 
 mod common;
+use common::SimpleLogger;
 
 #[test]
 fn test_it() {
+    log::set_logger(|max_log_level| {
+                        max_log_level.set(::log::LogLevelFilter::Debug);
+                        Box::new(SimpleLogger)
+                    })
+            .unwrap();
     const CONFIG_FILE: &str = "resources/mdup.yml";
     // Need to use temporary directories for this
     // Ammend the configuration
     let tmp_dir = env::temp_dir();
     let tmp_dir = tmp_dir.join("made_up_out");
     println!("Temp dir: {:?}", tmp_dir.to_string_lossy());
-    // let tmp_dir = tempdir::TempDir::new("made_up_out").expect("Failed to create temp dir");
     let mut config_content = common::read_from_file(CONFIG_FILE);
     let old_config_content = config_content.clone();
     config_content.push_str(&format!("out_dir: {:?}\n", tmp_dir.to_string_lossy()));
 
     println!("Writing config: {}", config_content);
-    // HACK Until work out why windows is failing
-    // common::write_to_file(CONFIG_FILE, config_content);
-    let tmp_dir = PathBuf::from("out");
+    common::write_to_file(CONFIG_FILE, config_content);
 
 
     // Let's start the testing
@@ -57,5 +59,5 @@ fn test_it() {
     assert!(common::check_file_exists(tmp_dir.to_string_lossy().to_string() +
                                       "/images/rustacean-orig-noshadow.png"));
     fs::remove_dir_all(tmp_dir).expect("Unable to delete tmp dir");
-    // common::write_to_file(CONFIG_FILE, old_config_content);
+    common::write_to_file(CONFIG_FILE, old_config_content);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -58,3 +58,20 @@ pub fn compare_string_content(expected: &str, actual: &str) {
 
     assert_eq!(expected, actual);
 }
+
+
+use log::{LogLevel, LogRecord, LogMetadata};
+
+pub struct SimpleLogger;
+
+impl ::log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &LogMetadata) -> bool {
+        metadata.level() <= LogLevel::Debug
+    }
+
+    fn log(&self, record: &LogRecord) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+}


### PR DESCRIPTION
Had to remove canonicalize to get Windows build passing. This was due to it prepending the file path with \\? which is some magical convention to overcome the max path length Windows decides to enforce. The main change is that it no longer owns a complete canonicalized path just the one provided.