### PR TITLE
Include template as string. Log tidy up.

### DIFF
--- a/src/config/config_macro.rs
+++ b/src/config/config_macro.rs
@@ -4,7 +4,8 @@ use serde_yaml;
 use super::file_utils;
 
 
-/// Constructs a configuration struct with accessors to each field.
+/// Constructs a configuration struct with accessors to each field and default fields.
+/// The macro will implement the `Default` trait for the values provided.
 macro_rules! configuration {
     (
         $(
@@ -70,13 +71,27 @@ macro_rules! configuration {
             }
     };
 }
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use serde_yaml;
 
-fn test_config_macro() {
+    use super::file_utils;
+
     configuration!{
         stylesheet, String, "".to_string();
         gen_index, bool, false;
         out_dir, String, "out".to_string();
         copy_resources, bool, true;
         title, String, "title".to_string()
+    }
+    #[test]
+    fn test_config_macro_default() {
+        let config_def = Configuration::default();
+        assert_eq!(config_def.stylesheet(), "".to_string());
+        assert_eq!(config_def.gen_index(), false);
+        assert_eq!(config_def.out_dir(), "out".to_string());
+        assert_eq!(config_def.copy_resources(), true);
+        assert_eq!(config_def.title(), "title".to_string());
     }
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -16,8 +16,7 @@ pub fn generate_index(files: &MarkdownFileList, config: &Configuration) -> Resul
     // Build the page from the template just to make it easier for future us
     let mut handlebars = Handlebars::new();
     handlebars
-        .register_template_file(TEMPLATE_NAME,
-                                &Path::new(&format!("templates/{}.hbs", TEMPLATE_NAME)))
+        .register_template_string(TEMPLATE_NAME, include_str!("../templates/index.hbs"))
         .unwrap();
 
     let mut data: BTreeMap<String, Value> = BTreeMap::new();
@@ -41,8 +40,7 @@ pub fn encapsulate_bare_html(content: String, config: &Configuration) -> Result<
     // Build the page from the template just to make it easier for future us
     let mut handlebars = Handlebars::new();
     handlebars
-        .register_template_file(TEMPLATE_NAME,
-                                &Path::new(&format!("templates/{}.hbs", TEMPLATE_NAME)))
+        .register_template_string(TEMPLATE_NAME, include_str!("../templates/basic.hbs"))
         .unwrap();
 
     let mut data: BTreeMap<String, String> = BTreeMap::new();

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -84,7 +84,7 @@ pub fn find_markdown_files<P: AsRef<Path>>(root_dir: P) -> Result<Vec<MarkdownFi
         let path = entry.path();
         if is_accepted_markdown_file(path) {
             info!("Adding file {:?}", path);
-            info!("Parent: {:?}", path.parent());
+            // info!("Parent: {:?}", path.parent());
             files.push(MarkdownFile::from(path));
         }
     }


### PR DESCRIPTION
Fixes issue found when running on files outside of crate. Templates are now loaded as strings instead of a file.